### PR TITLE
Make Strang type stable and efficient

### DIFF
--- a/src/strang.jl
+++ b/src/strang.jl
@@ -1,33 +1,63 @@
 export Strang
 
-using LinearAlgebra: SymTridiagonal
-
 """
-    Strang{T}([T=Float64,] n::Int)
+    Strang([T=Int,] n::Int)
 
-Construct `Strang` matrix with elements of type `T`,
-a special `SymTridiagonal` matrix named after Gilbert Strang.
+Construct `Strang` matrix with elements of type `T`.
+This special matrix named after Gilbert Strang
+is symmetric, tridiagonal, and Toeplitz.
+See Fig. 1 of [Julia paper](http://doi.org/10.1137/141000671).
 
 ```jldoctest
-julia> Strang(6)
-6×6 SymTridiagonal{Float64, Vector{Float64}}:
-  2.0  -1.0    ⋅     ⋅     ⋅     ⋅ 
- -1.0   2.0  -1.0    ⋅     ⋅     ⋅ 
-   ⋅   -1.0   2.0  -1.0    ⋅     ⋅ 
-   ⋅     ⋅   -1.0   2.0  -1.0    ⋅ 
-   ⋅     ⋅     ⋅   -1.0   2.0  -1.0
-   ⋅     ⋅     ⋅     ⋅   -1.0   2.0
+julia> Strang(4)
+4×4 Strang{Int64}:
+  2  -1   0   0
+ -1   2  -1   0
+  0  -1   2  -1
+  0   0  -1   2
 
 julia> Strang(Int16, 3)
-3×3 SymTridiagonal{Int16, Vector{Int16}}:
+3×3 Strang{Int16}:
   2  -1   0
  -1   2  -1
   0  -1   2
 ```
 """
-function Strang(::Type{T}, n::Int) where {T <: Number}
-    n > 0 || throw(ArgumentError("$n ≤ 0"))
-    return SymTridiagonal(T(2)*ones(T, n), -ones(T, n-1))
+struct Strang{T <: Number} <: AbstractMatrix{T}
+    n::Int
+
+    function Strang(::Type{T}, n::Int) where {T <: Number}
+        n > 0 || throw(ArgumentError("$n ≤ 0"))
+        return new{T}(n)
+     end
 end
 
-Strang(n::Int) = Strang(Float64, n)
+Strang(n::Int) = Strang(Int, n)
+
+# Properties
+size(s::Strang) = (s.n, s.n)
+LinearAlgebra.adjoint(s::Strang) = s
+LinearAlgebra.transpose(s::Strang) = s
+LinearAlgebra.issymmetric(s::Strang) = true
+LinearAlgebra.ishermitian(s::Strang) = true
+LinearAlgebra.isposdef(s::Strang) = true
+
+@inline Base.@propagate_inbounds function getindex(A::Strang{T}, i::Integer, j::Integer) where T
+    @boundscheck checkbounds(A, i, j)
+    if i == j
+        return T(2)
+    elseif i == j + 1 || i == j - 1
+        return -one(T)
+    else
+        return zero(T)
+    end
+end
+
+@inline Base.@propagate_inbounds function *(A::Strang{T}, x::AbstractVector) where T
+    @boundscheck length(x) == A.n || throw(ArgumentError("length(x) not n=$n"))
+    Base.require_one_based_indexing(x)
+    y = collect(T(2) * x) # from diagonal
+    y[1:end-1] .-= @view x[2:end]
+    y[2:end] .-= @view x[1:end-1]
+    return y
+end

--- a/src/strang.jl
+++ b/src/strang.jl
@@ -46,7 +46,7 @@ LinearAlgebra.isposdef(s::Strang) = true
     @boundscheck checkbounds(A, i, j)
     if i == j
         return T(2)
-    elseif i == j + 1 || i == j - 1
+    elseif abs(i-j) == 1
         return -one(T)
     else
         return zero(T)

--- a/src/strang.jl
+++ b/src/strang.jl
@@ -1,34 +1,33 @@
 export Strang
+
+using LinearAlgebra: SymTridiagonal
+
 """
-`Strang` matrix
+    Strang{T}([T=Float64,] n::Int)
 
-A special `SymTridiagonal` matrix named after Gilbert Strang
+Construct `Strang` matrix with elements of type `T`,
+a special `SymTridiagonal` matrix named after Gilbert Strang.
 
-```julia
+```jldoctest
 julia> Strang(6)
-6x6 Strang{Float64}:
-  2.0  -1.0   0.0   0.0   0.0   0.0
- -1.0   2.0  -1.0   0.0   0.0   0.0
-  0.0  -1.0   2.0  -1.0   0.0   0.0
-  0.0   0.0  -1.0   2.0  -1.0   0.0
-  0.0   0.0   0.0  -1.0   2.0  -1.0
-  0.0   0.0   0.0   0.0  -1.0   2.0
+6×6 SymTridiagonal{Float64, Vector{Float64}}:
+  2.0  -1.0    ⋅     ⋅     ⋅     ⋅ 
+ -1.0   2.0  -1.0    ⋅     ⋅     ⋅ 
+   ⋅   -1.0   2.0  -1.0    ⋅     ⋅ 
+   ⋅     ⋅   -1.0   2.0  -1.0    ⋅ 
+   ⋅     ⋅     ⋅   -1.0   2.0  -1.0
+   ⋅     ⋅     ⋅     ⋅   -1.0   2.0
+
+julia> Strang(Int16, 3)
+3×3 SymTridiagonal{Int16, Vector{Int16}}:
+  2  -1   0
+ -1   2  -1
+  0  -1   2
 ```
 """
-struct Strang{T} <: AbstractArray{T, 2}
-    n :: Int
+function Strang(::Type{T}, n::Int) where {T <: Number}
+    n > 0 || throw(ArgumentError("$n ≤ 0"))
+    return SymTridiagonal(T(2)*ones(T, n), -ones(T, n-1))
 end
-Strang(n::Int) = Strang{Float64}(n)
-strang(T, n)= n >1 ? SymTridiagonal(2ones(T, n),-ones(T, n-1)) :
-              n==1 ? Diagonal([2one(T)]) : error("Invalid dimension ", n)
-function getindex(S::Strang{T}, i, j) where T
-    i == j && return 2
-    abs(i - j) == 1 && return -1
-    0
-end
-getindex(S::Strang{T}, I...) where T = getindex(S,ind2sub(size(S),I...)...)
-size(S::Strang, r::Int) = r==1 || r==2 ? S.n : throw(ArgumentError("Invalid dimension $r"))
-size(S::Strang) = S.n, S.n
-Matrix(S::Strang{T}) where T = Matrix(strang(T, S.n))
-*(A::VecOrMat{T}, S::Strang{T}) where T = A*Matrix(S)
-*(S::Strang{T}, A::VecOrMat{T}) where T = Matrix(S)*A
+
+Strang(n::Int) = Strang(Float64, n)

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -1,7 +1,7 @@
 # strang.jl
 
 using SpecialMatrices: Strang
-using LinearAlgebra: diagm
+using LinearAlgebra: diagm, issymmetric, ishermitian, isposdef
 using Test: @test, @testset, @test_throws, @inferred
 
 @testset "strang" begin
@@ -23,4 +23,10 @@ using Test: @test, @testset, @test_throws, @inferred
     x = rand(n)
     y = @inferred *(A, x)
     @test y ≈ Matrix(A) * x
+
+    @test transpose(A) === A
+    @test adjoint(A) === A
+    @test issymmetric(A)
+    @test ishermitian(A)
+    @test isposdef(A)
 end

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -1,20 +1,20 @@
 # strang.jl
 
 using SpecialMatrices: Strang
-using LinearAlgebra: diagm, SymTridiagonal
+using LinearAlgebra: diagm
 using Test: @test, @testset, @test_throws, @inferred
 
 @testset "strang" begin
     @test_throws ArgumentError Strang(0)
 
-    Z = @inferred Strang(1)
-    @test Matrix(Z) == reshape([2.0],(1,1))
+    A = @inferred Strang(1)
+    @test Matrix(A) == reshape([2.0], (1,1))
 
     n = 5
-    Z = @inferred Strang(Int64, 5)
-    @test Z == diagm(0 => 2ones(n), 1 => -ones(n-1), -1 => -ones(n-1))
+    A = @inferred Strang(Int16, 5)
+    @test A isa Strang{Int16}
+    @test A == diagm(0 => 2ones(n), 1 => -ones(n-1), -1 => -ones(n-1))
 
-    @test Z isa SymTridiagonal
+    x = rand(n)
+    @test A * x ≈ Matrix(A) * x
 end
-
-# no further tests are needed because SymTridiagonal is tested elsewhere

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -1,23 +1,20 @@
-Z = Strang(1)
-@test Matrix(Z) == reshape([2.0],(1,1))
+# strang.jl
 
-n = rand(1:10)
-Z = Strang(n)
+using SpecialMatrices: Strang
+using LinearAlgebra: diagm, SymTridiagonal
+using Test: @test, @testset, @test_throws, @inferred
 
-for i in 1:n, j in 1:n
-    i==j && @test Z[i,j] == 2
-    abs(i-j)==1 && @test Z[i,j] == -1
-    abs(i-j)>1 && @test Z[i,j] == 0
+@testset "strang" begin
+    @test_throws ArgumentError Strang(0)
+
+    Z = @inferred Strang(1)
+    @test Matrix(Z) == reshape([2.0],(1,1))
+
+    n = 5
+    Z = @inferred Strang(Int64, 5)
+    @test Z == diagm(0 => 2ones(n), 1 => -ones(n-1), -1 => -ones(n-1))
+
+    @test Z isa SymTridiagonal
 end
 
-A = Strang(10)
-u = ones(10)
-@test A*u == [1.0;zeros(8);1.0]
-
-#Matvec product
-b = randn(n)
-@test Z*b ≈ Matrix(Z)*b
-
-m = rand(1:10)
-A = randn(m, n)
-@test A*Z ≈ A*Matrix(Z)
+# no further tests are needed because SymTridiagonal is tested elsewhere

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -15,6 +15,12 @@ using Test: @test, @testset, @test_throws, @inferred
     @test A isa Strang{Int16}
     @test A == diagm(0 => 2ones(n), 1 => -ones(n-1), -1 => -ones(n-1))
 
+    @test (@inferred getindex(A, 1, 2)) == -1
+    @test A[begin] == 2
+    @test A[end] == 2
+    @test A[1,end] == 0
+
     x = rand(n)
-    @test A * x ≈ Matrix(A) * x
+    y = @inferred *(A, x)
+    @test y ≈ Matrix(A) * x
 end


### PR DESCRIPTION
The previous version of `Strang`  returned (typically) `SymTridiagonal` but `Diagonal` in the case `n=1`.  This is problematic for two reasons:
- it was not type stable
- it does not satisfy the guideline that a constructor like `Strang` should return a `Strang` type.

This PR implements a proper `Strang` type.  It provides efficient `getindex` and multiply `A * x` but nothing else.
Other properties just inherit from the full matrix.

Technically this a breaking change because the returned type is different.