### PR TITLE
Update Frobenius to use 3-arg `mul!` and improve test coverage

### DIFF
--- a/src/frobenius.jl
+++ b/src/frobenius.jl
@@ -1,6 +1,7 @@
 export Frobenius
+
 """
-[`Frobenius` matrix](http://en.wikipedia.org/wiki/Frobenius_matrix)
+    [`Frobenius` matrix](http://en.wikipedia.org/wiki/Frobenius_matrix)
 
 Frobenius matrices or Gaussian elimination matrices of the form
 
@@ -15,103 +16,118 @@ Frobenius matrices or Gaussian elimination matrices of the form
 [ ... ck ...   1]
 ```
 
-i.e. an identity matrix with nonzero subdiagonal elements along a single column.
+i.e., an identity matrix with possibly nonzero subdiagonal elements
+along a single column.
 
-```
- In this implementation, the subdiagonal of the nonzero column is stored as a
- dense vector, so that the size can be inferred automatically as j+k where j is
- the index of the column and k is the number of subdiagonal elements.
-```
+In this implementation,
+the subdiagonal of the nonzero column is stored as a dense vector,
+so that the size can be inferred automatically as j+k,
+where j is the column index and k is the number of subdiagonal elements.
 
 ```julia
 julia> using SpecialMatrices
 
-julia> F=Frobenius(3, [1.0,2.0,3.0]) #Specify subdiagonals of column 3
-6x6 Frobenius{Float64}:
- 1.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  0.0  0.0  0.0  0.0
- 0.0  0.0  1.0  0.0  0.0  0.0
- 0.0  0.0  1.0  1.0  0.0  0.0
- 0.0  0.0  2.0  0.0  1.0  0.0
- 0.0  0.0  3.0  0.0  0.0  1.0
+julia> F = Frobenius(3, 4:6) # Specify subdiagonals of column 3
+6×6 Frobenius{Int64}:
+ 1  0  0  0  0  0
+ 0  1  0  0  0  0
+ 0  0  1  0  0  0
+ 0  0  4  1  0  0
+ 0  0  5  0  1  0
+ 0  0  6  0  0  1
 
-julia> inv(F) #Special form of inverse
-6x6 Frobenius{Float64}:
- 1.0  0.0   0.0  0.0  0.0  0.0
- 0.0  1.0   0.0  0.0  0.0  0.0
- 0.0  0.0   1.0  0.0  0.0  0.0
- 0.0  0.0  -1.0  1.0  0.0  0.0
- 0.0  0.0  -2.0  0.0  1.0  0.0
- 0.0  0.0  -3.0  0.0  0.0  1.0
+julia> inv(F) # Special form of inverse
+6×6 Frobenius{Int64}:
+ 1  0   0  0  0  0
+ 0  1   0  0  0  0
+ 0  0   1  0  0  0
+ 0  0  -4  1  0  0
+ 0  0  -5  0  1  0
+ 0  0  -6  0  0  1
 
-julia> F*F #Special form preserved if the same column has the subdiagonals
-6x6 Frobenius{Float64}:
- 1.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  0.0  0.0  0.0  0.0
- 0.0  0.0  1.0  0.0  0.0  0.0
- 0.0  0.0  2.0  1.0  0.0  0.0
- 0.0  0.0  4.0  0.0  1.0  0.0
- 0.0  0.0  6.0  0.0  0.0  1.0
+julia> F*F # Special form preserved if the same column has the subdiagonals
+6×6 Frobenius{Int64}:
+ 1  0   0  0  0  0
+ 0  1   0  0  0  0
+ 0  0   1  0  0  0
+ 0  0   8  1  0  0
+ 0  0  10  0  1  0
+ 0  0  12  0  0  1
 
-julia> F*Frobenius(2, [5.0,4.0,3.0,2.0]) #Promotes to Matrix
-6x6 Array{Float64,2}:
- 1.0   0.0  0.0  0.0  0.0  0.0
- 0.0   1.0  0.0  0.0  0.0  0.0
- 0.0   5.0  1.0  0.0  0.0  0.0
- 0.0   9.0  1.0  1.0  0.0  0.0
- 0.0  13.0  2.0  0.0  1.0  0.0
- 0.0  17.0  3.0  0.0  0.0  1.0
+julia> F*Frobenius(2, 2:5) # Promotes to Matrix
+6×6 Matrix{Float64}:
+ 1   0  0  0  0  0
+ 0   1  0  0  0  0
+ 0   2  1  0  0  0
+ 0  11  4  1  0  0
+ 0  14  5  0  1  0
+ 0  17  6  0  0  1
 
-julia> F*[10.0,20,30,40,50,60.0]
-6-element Array{Float64,1}:
+julia> F * [10.0,20,30,40,50,60.0]
+6-element Vector{Float64}:
   10.0
   20.0
   30.0
-  70.0
- 110.0
- 150.0
+ 160.0
+ 200.0
+ 240.0
 ```
 """
-struct Frobenius{T} <: AbstractArray{T, 2}
+struct Frobenius{T} <: AbstractMatrix{T}
     colidx :: Int
     c :: Vector{T}
+    function Frobenius(colidx::Int, c::AbstractVector{T}) where {T <: Number}
+        1 ≤ colidx || throw("Bad column index $colidx")
+        return new{T}(colidx, collect(c))
+    end
 end
 
-#Basic property computations
-size(F::Frobenius, r::Int) = (r==1 || r==2) ? F.colidx + length(F.c) :
-    throw(ArgumentError("Frobenius matrix is of rank 2"))
-
+# size
 function size(F::Frobenius)
     n = F.colidx + length(F.c)
-    n, n
+    return n, n
 end
 
-#XXX Inefficient but works
-getindex(F::Frobenius, i, j) = getindex(Matrix(F), i, j)
-isassigned(F::Frobenius, i::Integer, j::Integer) = isassigned(Matrix(F), i, j)
-
-function Matrix(F::Frobenius{T}) where T
-    M = Matrix{T}(I, size(F))
-    M[F.colidx+1:end, F.colidx] = F.c
-    M
+# getindex
+@inline Base.@propagate_inbounds function getindex(F::Frobenius{T}, i::Integer, j::Integer) where {T}
+    @boundscheck checkbounds(F, i, j)
+    return (i == j) ? one(T) :
+        (i > j == F.colidx) ?
+        (@inbounds F.c[i-F.colidx]) :
+        zero(T)
 end
 
-#Linear algebra stuff
-function mul!(F::Frobenius{T}, b::Vector{T}) where T
-    (n = size(F, 2)) == length(b) || throw(DimensionMismatch("$n $(length(b))"))
-    for i=F.colidx+1:n
-        b[i] += F.c[i-F.colidx] * b[F.colidx]
-    end
-    b
-end
-*(F::Frobenius{T}, b::Vector{T}) where T = mul!(F, copy(b))
 
-function *(F::Frobenius{T}, G::Frobenius{T}) where T
+# Linear algebra
+
+# 3-argument mul! mutates first argument: y <= F * x
+# *(F, x) = F * x derives from this automatically in Base
+function mul!(y::Vector, F::Frobenius, x::AbstractVector)
+    @boundscheck (n = size(F, 2)) == length(x) == length(y) ||
+        throw(DimensionMismatch("$n $(length(y)) $(length(x))"))
+    j = F.colidx
+    copyto!(y, x)
+    @inbounds @. (@view y[(j+1):end]) += F.c * x[j]
+    return y
+end
+
+# This product is not type stable (result could be Frobenius or Matrix).
+#=
+It could be stable if we put the column index "j" as a type parameter.
+Here is the basic idea:
+function *(F::Frobenius{TF,j}, G::Frobenius{TG,j}) where {TF, TG, j}
+    size(F) == size(G) || throw(DimensionMismatch())
+    return Frobenius(j, F.c + G.c)
+end
+=#
+
+function *(F::Frobenius, G::Frobenius)
     (n = size(F, 2)) == size(G, 2) || throw(DimensionMismatch(""))
     if F.colidx == G.colidx #Answer is still expressible as a Frobenius
         return Frobenius(F.colidx, F.c + G.c)
     else
-        M = Matrix(F)
+        T = promote_type(eltype(F), eltype(G))
+        M = Matrix{T}(F)
         M[G.colidx+1:end, G.colidx] = F.colidx < G.colidx ? G.c :
             Frobenius(F.colidx-G.colidx, F.c) * G.c
         return M

--- a/test/frobenius.jl
+++ b/test/frobenius.jl
@@ -1,6 +1,64 @@
-m=rand(2:10)
-n=rand(1:10)
-Z = Frobenius(m, randn(n)) #size m+n
+using LinearAlgebra: I
+import LinearAlgebra: mul!
+
+n = 7
+j = 4
+function test_frobenius(col)
+    A = @inferred Frobenius(j, col) # AbstractVector
+    @test A isa Frobenius
+
+    # size
+    @test size(A) == (n,n)
+    @test size(A,1) == n
+    @test size(A,2) == n
+    @test size(A,3) == 1
+
+    # inv
+    Ai = @inferred inv(A)
+    @test Ai * A == I
+
+    # getindex
+    @test A[1,1] == 1
+    @test (@inferred getindex(A, 2, 2)) == 1
+    @test (@inferred getindex(A, j+2, j)) == col[2]
+    @test_throws BoundsError getindex(A, 8, 8)
+
+    # Matrix
+    M = @inferred Matrix(A)
+    @test M isa Matrix
+
+    # mul! *
+    y = Vector{Float32}(undef, n)
+    x = 10 * (1:n)
+    @inferred mul!(y, A, x)
+    @test y == Matrix(A) * x
+    @test y == A * x
+
+    x = randn(n)
+    @inferred mul!(y, A, x)
+    @test y ≈ Matrix(A) * x
+    @test y ≈ A * x
+
+    # Matrix-Matrix
+    B = Frobenius(j, randn(size(col))) # another one of the same column
+#   C = @inferred *(A, B) # A * B (NOT type stable)
+    C = *(A, B) # A * B
+    @test C isa Frobenius
+    @test Matrix(C) ≈ Matrix(A) * Matrix(B)
+
+    B = Frobenius(j-1, randn(1 .+ size(col))) # different column
+    C = *(A, B) # A * B
+    @test C isa Matrix
+    @test Matrix(C) ≈ Matrix(A) * Matrix(B)
+end
+
+for col in (1:3, 2.0:4.0) # test both Int and Float32 types
+   test_frobenius(col)
+end
+
+m = rand(2:10)
+n = rand(1:10)
+Z = Frobenius(m, randn(n)) # size m+n
 
 #Special properties
 @test Matrix(inv(Z)) ≈ inv(Matrix(Z))
@@ -13,6 +71,6 @@ b = randn(m+n)
 Y1 = Frobenius(m, randn(n)) #Another one of the same column
 @test Matrix(Y1*Z) ≈ Matrix(Y1)*Matrix(Z)
 
-n2=rand(1:(m+n-1))
+n2 = rand(1:(m+n-1))
 Y2 = Frobenius(m+n-n2, randn(n2)) #Probably not the same column
 @test Matrix(Y2*Z) ≈ Matrix(Y2)*Matrix(Z)


### PR DESCRIPTION
My initial purpose here was to simply improve test coverage.
But when working on that, I noted that the `mul!` implementation here was incompatible with the modern [3-arg `mul!`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.mul!) so I have updated that as well.
This is a breaking change so eventually the version number will need incremented.
But `companion` has the same outdated `mul!` so let's fix that first before making a new release.