### PR TITLE
Ensure 1-based indexing

### DIFF
--- a/src/companion.jl
+++ b/src/companion.jl
@@ -74,8 +74,9 @@ end
 
 # Linear algebra
 
-# 3-argument mul! mutates first argument: y <= C * x
+# 3-argument mul! mutates first argument: y ⇐ C * x
 function mul!(y::Vector, C::Companion, x::AbstractVector)
+    Base.require_one_based_indexing(x)
     @boundscheck length(y) == length(x) == size(C, 1) ||
         throw(DimensionMismatch("mul! arguments incompatible sizes"))
     z = x[end]

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -76,6 +76,7 @@ size(V::Vandermonde) = (length(V.c), length(V.c))
 # solvers
 
 function \(V::Adjoint{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1, T2}
+    Base.require_one_based_indexing(y)
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)
@@ -84,6 +85,7 @@ function \(V::Adjoint{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1,
 end
 
 function \(V::Transpose{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1, T2}
+    Base.require_one_based_indexing(y)
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)
@@ -92,6 +94,7 @@ function \(V::Transpose{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T
 end
 
 function \(V::Vandermonde{T1}, y::AbstractVecOrMat{T2}) where {T1, T2}
+    Base.require_one_based_indexing(y)
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)


### PR DESCRIPTION
To address #71.
It is possible that some of the checking here is unnecessarily conservative, but to relax any of these checks there should be CI tests for correctness.  So for now it is safer to be conservative.