### PR TITLE
Fix links to "main" branch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -46,7 +46,7 @@ isci = get(ENV, "CI", nothing) == "true"
 
 format = Documenter.HTML(;
     prettyurls = isci,
-    edit_link = "master",
+    edit_link = "main",
     canonical = "https://$org.github.io/$repo.jl/stable/",
 #   assets = String[],
 )
@@ -65,7 +65,7 @@ makedocs(;
 if isci
     deploydocs(;
         repo = "github.com/$base",
-        devbranch = "master",
+        devbranch = "main",
         devurl = "dev",
         versions = ["stable" => "v^", "dev" => "dev"],
         forcepush = true,


### PR DESCRIPTION
Following best practices, I've renamed the main branch to be `main` and this in turn requires this tweak to `docs/make.jl`.